### PR TITLE
Skip lint on docs.rs and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfe_bfgs"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Paul Kernfeld <paulkernfeld@gmail.com>", "SauersML"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wolfe_bfgs = "0.2.0"
+wolfe_bfgs = "0.2.1"
 ```
 
 ### Example: Minimizing the Rosenbrock Function

--- a/build.rs
+++ b/build.rs
@@ -1117,10 +1117,15 @@ fn main() {
         println!("cargo:rustc-env=GNOMON_RELEASE_TAG={}", release_tag);
     }
 
-    // Skip lint checks during release builds or cross-compilation
+    // Skip lint checks during release builds, cross-compilation, or docs.rs builds
     // (the grep crate won't be available in target deps during cross-compile)
     if std::env::var("GNOMON_SKIP_LINT_CHECKS").is_ok() {
         update_stage("skipping lint checks (GNOMON_SKIP_LINT_CHECKS set)");
+        return;
+    }
+
+    if std::env::var("DOCS_RS").is_ok() {
+        update_stage("skipping lint checks (docs.rs build)");
         return;
     }
 


### PR DESCRIPTION
## Summary
- skip build-script lint checks when running on docs.rs to avoid missing build dependencies
- bump crate version to 0.2.1 and update README example

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695879fabf8c832e852a3cb90dc5bc3c)